### PR TITLE
build-tonto.sh now sets correct src/target version, and has an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,16 @@ tools/mk-irscrutinizer-html.sh.  It is also directly accessible
 [online](http://www.harctoolbox.org/IrScrutinizer.html#Appendix.+Building+from+sources)
 (may be behind the version here.)
 
-## Sourceforge outage
+## Dependencies backup
 
-During to the current Soureforge outage, the
-[ExchangeIR](http://www.harctoolbox.org/downloads/exchangeir.tar.gz)  and the
-[DecodeIR](http://www.harctoolbox.org/downloads/decodeir.tar.gz) sources are
-available on www.harctoolbox.org.
+"Inspired" by the recent Soureforge outage, I decided to make the sources of the
+dependencies available on www.harctoolbox.org. These are the
+github/sourceforge repositories, corresponding to the right tag or
+commit, but without any patches applies. These are:
+
+* [ExchangeIR](http://www.harctoolbox.org/downloads/exchangeir.tar.gz)
+* [DecodeIR](http://www.harctoolbox.org/downloads/decodeir.tar.gz)
+* [JCommander](http://www.harctoolbox.org/downloads/jcommander.tar.gz)
+* [Minimal-Json](http://www.harctoolbox.org/downloads/minimal-json.tar.gz)
+* [Tonto](http://www.harctoolbox.org/downloads/tonto.tar.gz)
+* [Wakeonlan](http://www.harctoolbox.org/downloads/wakeonlan-1.0.0.zip)

--- a/tools/build-tonto.sh
+++ b/tools/build-tonto.sh
@@ -2,7 +2,7 @@
 git clone https://github.com/stewartoallen/tonto
 cd tonto
 git checkout be1657a
-sed -i '/signjar/d' build.xml
+sed -i -e '/signjar/d' -e 's/<javac/<javac source="1.6" target="1.6"/' build.xml
 ant all
 mvn install:install-file \
     -DgroupId=com.mrallen \
@@ -12,6 +12,11 @@ mvn install:install-file \
     -Dfile=jars/tonto.jar
 
 # End here if the serial communication library is not wanted
+if [ "$1" = "-n" ] ; then
+    echo "Not building the shared library"
+    exit 0
+fi
+
 cd libs
 sh ./build-fedora.sh
 sudo install -D libjnijcomm.so /usr/local/lib/tonto/libjnijcomm.so


### PR DESCRIPTION
for omitting building shared library. README.md update.
